### PR TITLE
Feature/likes & anon_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Local development artifacts
+.venv/
+.DS_Store
+
+# SQLite databases (generated at runtime)
+*.db
+*.sqlite
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # webtoon-note-BE
+
+## Review Creation API
+
+| Endpoint | Method |
+| --- | --- |
+| `/webtoons/review/` | POST |
+
+### Query Parameters
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `webtoon_id` | integer (>= 1) | Yes | Target webtoon ID from `normalized_webtoon.id`. |
+
+### Request Body
+
+```json
+{
+  "content": "스토리가 정말 흥미진진해요!",
+  "rating": 4.5
+}
+```
+
+### Validation Rules
+
+- `content`: 1–2000 characters, Unicode text permitted.
+- `rating`: floating point between 0 and 5 inclusive (FastAPI/Pydantic reject anything outside the range).
+
+### Response `201 Created`
+
+```json
+{
+  "id": 15,
+  "webtoon_id": 1,
+  "content": "스토리가 정말 흥미진진해요!",
+  "rating": 4.5,
+  "likes": 0,
+  "created_at": "2025-11-12T18:40:00",
+  "anonymous_user_id": "a38f8a13-41be-4ebe-9fc7-3f79bfb652f5"
+}
+```
+
+### Cookie Policy
+
+- The API reads the `anon_id` cookie to attribute reviews to anonymous visitors.
+- When the cookie is missing, a new UUID is minted and returned in the response headers with:
+  - `HttpOnly` flag set.
+  - `SameSite=Lax`.
+  - `max-age` of one year.
+
+### Side Effects after Successful Review Creation
+
+- The review is persisted in `reviews` with `likes` defaulting to `0`.
+- Corresponding entry in `webtoon_rating_stats` is inserted/updated to keep the aggregate review count and average rating in sync (`average = (prev_sum + new_rating) / new_count`).
+
+### Failure Responses
+
+| Status | When | Body |
+| --- | --- | --- |
+| `404` | `webtoon_id` does not exist in `normalized_webtoon`. | `{"detail": "해당 웹툰을 찾을 수 없습니다."}` |
+| `422` | Validation fails (missing fields, rating out of range, empty content, etc.). | FastAPI validation payload detailing the offending field. |
+| `500` | Unexpected server/database errors (transaction rollbacks are logged; a generic message is returned). | `{"detail": "Internal Server Error"}` |
+
+### Notes
+
+- `likes` is returned to support future “like review” features but currently always starts at zero.
+- Additional moderation (profanity filtering, spam detection) can be layered on top of the service without changing the contract.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `webtoon_id` | integer (>= 1) | Yes | Target webtoon ID from `normalized_webtoon.id`. |
+| `webtoon_id` | string | Yes | Target webtoon ID from `normalized_webtoon.id` (e.g., `kakao_1000`). |
 
 ### Request Body
 
@@ -31,7 +31,7 @@
 ```json
 {
   "id": 15,
-  "webtoon_id": 1,
+  "webtoon_id": "kakao_1000",
   "content": "스토리가 정말 흥미진진해요!",
   "rating": 4.5,
   "likes": 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pydantic_core==2.33.2
 python-dateutil==2.9.0.post0
 pytz==2025.2
 six==1.17.0
+SQLAlchemy==2.0.36
 sniffio==1.3.1
 starlette==0.47.2
 typing-inspection==0.4.1

--- a/webtoon/db/__init__.py
+++ b/webtoon/db/__init__.py
@@ -1,0 +1,17 @@
+"""Database utilities exposed by the webtoon package."""
+
+from __future__ import annotations
+
+from webtoon.db.session import Base, engine, get_session
+
+
+def init_db() -> None:
+    """Create all ORM tables registered on the declarative base."""
+
+    # Import models so they are registered with SQLAlchemy's metadata.
+    from webtoon import models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+
+
+__all__ = ["Base", "engine", "get_session", "init_db"]

--- a/webtoon/db/session.py
+++ b/webtoon/db/session.py
@@ -1,32 +1,31 @@
-"""SQLAlchemy engine and session helpers for the webtoon service."""
+"""SQLAlchemy session helpers for the webtoon backend."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Generator
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-BASE_DIR = Path(__file__).resolve().parent.parent
-DB_FILE = BASE_DIR / "webtoon_database.sqlite"
-DATABASE_URL = f"sqlite:///{DB_FILE}"
+from webtoon.database import DB_PATH
 
 
 class Base(DeclarativeBase):
-    """Declarative base class shared by all ORM models."""
+    """Base class for all ORM models."""
+
+
+DATABASE_URL = f"sqlite:///{DB_PATH}"
 
 
 engine = create_engine(
     DATABASE_URL,
     connect_args={"check_same_thread": False},
-    future=True,
 )
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 
 def get_session() -> Generator[Session, None, None]:
-    """Provide a scoped SQLAlchemy session for request handlers."""
+    """Yield a database session that is cleaned up after the request."""
 
     db = SessionLocal()
     try:

--- a/webtoon/db/session.py
+++ b/webtoon/db/session.py
@@ -1,0 +1,35 @@
+"""SQLAlchemy engine and session helpers for the webtoon service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DB_FILE = BASE_DIR / "webtoon_database.sqlite"
+DATABASE_URL = f"sqlite:///{DB_FILE}"
+
+
+class Base(DeclarativeBase):
+    """Declarative base class shared by all ORM models."""
+
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    future=True,
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """Provide a scoped SQLAlchemy session for request handlers."""
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/webtoon/dependencies/__init__.py
+++ b/webtoon/dependencies/__init__.py
@@ -1,0 +1,5 @@
+"""Dependency helpers exposed by the webtoon package."""
+
+from webtoon.dependencies.auth import get_anonymous_user_id
+
+__all__ = ["get_anonymous_user_id"]

--- a/webtoon/dependencies/auth.py
+++ b/webtoon/dependencies/auth.py
@@ -1,0 +1,28 @@
+"""Helpers for handling anonymous user tracking."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Request, Response
+
+
+COOKIE_NAME = "anon_id"
+
+
+def get_anonymous_user_id(request: Request, response: Response) -> str:
+    """Return the anon_id cookie (or issue a new one if missing)."""
+
+    current_id = request.cookies.get(COOKIE_NAME)
+    if current_id:
+        return current_id
+
+    new_id = str(uuid.uuid4())
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=new_id,
+        httponly=True,
+        samesite="lax",
+        max_age=60 * 60 * 24 * 365,  # 1 year
+    )
+    return new_id

--- a/webtoon/main.py
+++ b/webtoon/main.py
@@ -1,9 +1,13 @@
 # webtoon/main.py
 from fastapi import FastAPI
+
+from webtoon.db import init_db
+from webtoon.routers.search import router as search_router
 from webtoon.routers.webtoons import router as webtoons_router
-from webtoon.routers.search import router as search_router 
+
 
 app = FastAPI()
+init_db()
 
 # 라우터 등록
 app.include_router(webtoons_router)

--- a/webtoon/main.py
+++ b/webtoon/main.py
@@ -1,14 +1,34 @@
 # webtoon/main.py
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
-from webtoon.db import init_db
+from webtoon.db import Base, engine
+from webtoon.routers.reviews import router as reviews_router
 from webtoon.routers.search import router as search_router
 from webtoon.routers.webtoons import router as webtoons_router
 
-
 app = FastAPI()
-init_db()
+
+
+@app.on_event("startup")
+def ensure_tables_exist() -> None:
+    """Create ORM-managed tables if they don't already exist."""
+
+    from webtoon import models  # noqa: F401  (import registers models with Base)
+
+    Base.metadata.create_all(bind=engine)
+
+
+# CORS 미들웨어 설정
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],            # 모든 도메인 허용
+    allow_credentials=True,         # 쿠키, 인증 정보 허용
+    allow_methods=["*"],            # 모든 HTTP 메서드 허용
+    allow_headers=["*"],            # 모든 헤더 허용
+)
 
 # 라우터 등록
 app.include_router(webtoons_router)
 app.include_router(search_router)
+app.include_router(reviews_router)

--- a/webtoon/main.py
+++ b/webtoon/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from webtoon.db import Base, engine
+from webtoon.routers.auth import router as auth_router
 from webtoon.routers.reviews import router as reviews_router
 from webtoon.routers.search import router as search_router
 from webtoon.routers.webtoons import router as webtoons_router
@@ -32,3 +33,4 @@ app.add_middleware(
 app.include_router(webtoons_router)
 app.include_router(search_router)
 app.include_router(reviews_router)
+app.include_router(auth_router)

--- a/webtoon/models/__init__.py
+++ b/webtoon/models/__init__.py
@@ -1,6 +1,7 @@
 """ORM models available for import."""
 
 from webtoon.models.review import Review
+from webtoon.models.review_like import ReviewLike
 from webtoon.models.webtoon_rating_stats import WebtoonRatingStats
 
-__all__ = ["Review", "WebtoonRatingStats"]
+__all__ = ["Review", "ReviewLike", "WebtoonRatingStats"]

--- a/webtoon/models/__init__.py
+++ b/webtoon/models/__init__.py
@@ -1,0 +1,5 @@
+"""SQLAlchemy models for the webtoon backend."""
+
+from webtoon.models.review import Review
+
+__all__ = ["Review"]

--- a/webtoon/models/__init__.py
+++ b/webtoon/models/__init__.py
@@ -1,5 +1,6 @@
-"""SQLAlchemy models for the webtoon backend."""
+"""ORM models available for import."""
 
 from webtoon.models.review import Review
+from webtoon.models.webtoon_rating_stats import WebtoonRatingStats
 
-__all__ = ["Review"]
+__all__ = ["Review", "WebtoonRatingStats"]

--- a/webtoon/models/review.py
+++ b/webtoon/models/review.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Column, DateTime, Float, Integer, String, Text, func
 
 from webtoon.db.session import Base
 
@@ -13,12 +13,7 @@ class Review(Base):
     __tablename__ = "reviews"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    webtoon_id = Column(
-        Integer,
-        ForeignKey("normalized_webtoon.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
+    webtoon_id = Column(Integer, nullable=False, index=True)
     content = Column(Text, nullable=False)
     rating = Column(Float, nullable=False)
     likes = Column(Integer, nullable=False, default=0, server_default="0")

--- a/webtoon/models/review.py
+++ b/webtoon/models/review.py
@@ -13,7 +13,7 @@ class Review(Base):
     __tablename__ = "reviews"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    webtoon_id = Column(Integer, nullable=False, index=True)
+    webtoon_id = Column(String, nullable=False, index=True)
     content = Column(Text, nullable=False)
     rating = Column(Float, nullable=False)
     likes = Column(Integer, nullable=False, default=0, server_default="0")

--- a/webtoon/models/review.py
+++ b/webtoon/models/review.py
@@ -1,0 +1,21 @@
+"""ORM mapping for storing user reviews on webtoons."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Float, Integer, String, Text, func
+
+from webtoon.db.session import Base
+
+
+class Review(Base):
+    """Represents a single user review for a specific webtoon."""
+
+    __tablename__ = "reviews"
+
+    id = Column(Integer, primary_key=True, index=True)
+    webtoon_id = Column(Integer, nullable=False, index=True)
+    content = Column(Text, nullable=False)
+    rating = Column(Float, nullable=False)
+    likes = Column(Integer, nullable=False, default=0, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.current_timestamp())
+    anonymous_user_id = Column(String(length=64), nullable=False, index=True)

--- a/webtoon/models/review.py
+++ b/webtoon/models/review.py
@@ -1,21 +1,30 @@
-"""ORM mapping for storing user reviews on webtoons."""
+"""SQLAlchemy model describing individual webtoon reviews."""
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text, func
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Text, func
 
 from webtoon.db.session import Base
 
 
 class Review(Base):
-    """Represents a single user review for a specific webtoon."""
+    """Represents a user-submitted review for a specific webtoon."""
 
     __tablename__ = "reviews"
 
-    id = Column(Integer, primary_key=True, index=True)
-    webtoon_id = Column(Integer, nullable=False, index=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    webtoon_id = Column(
+        Integer,
+        ForeignKey("normalized_webtoon.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     content = Column(Text, nullable=False)
     rating = Column(Float, nullable=False)
     likes = Column(Integer, nullable=False, default=0, server_default="0")
-    created_at = Column(DateTime(timezone=True), server_default=func.current_timestamp())
-    anonymous_user_id = Column(String(length=64), nullable=False, index=True)
+    anonymous_user_id = Column(String(36), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.current_timestamp(),
+    )

--- a/webtoon/models/review.py
+++ b/webtoon/models/review.py
@@ -23,3 +23,9 @@ class Review(Base):
         nullable=False,
         server_default=func.current_timestamp(),
     )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )

--- a/webtoon/models/review_like.py
+++ b/webtoon/models/review_like.py
@@ -1,0 +1,25 @@
+"""Tracks which anonymous users liked which reviews."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+
+from webtoon.db.session import Base
+
+
+class ReviewLike(Base):
+    """Association table storing unique (review_id, anonymous_user_id) pairs."""
+
+    __tablename__ = "review_likes"
+
+    review_id = Column(
+        Integer,
+        ForeignKey("reviews.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    anonymous_user_id = Column(String(36), primary_key=True)
+    liked_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.current_timestamp(),
+    )

--- a/webtoon/models/webtoon_rating_stats.py
+++ b/webtoon/models/webtoon_rating_stats.py
@@ -1,0 +1,22 @@
+"""Stores aggregate rating stats per webtoon."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Float, Integer, func
+
+from webtoon.db.session import Base
+
+
+class WebtoonRatingStats(Base):
+    """Tracks review counts and average rating per webtoon."""
+
+    __tablename__ = "webtoon_rating_stats"
+
+    webtoon_id = Column(Integer, primary_key=True)
+    average_rating = Column(Float, nullable=False, default=0.0, server_default="0")
+    review_count = Column(Integer, nullable=False, default=0, server_default="0")
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+    )

--- a/webtoon/models/webtoon_rating_stats.py
+++ b/webtoon/models/webtoon_rating_stats.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Float, Integer, func
+from sqlalchemy import Column, DateTime, Float, Integer, String, func
 
 from webtoon.db.session import Base
 
@@ -12,7 +12,7 @@ class WebtoonRatingStats(Base):
 
     __tablename__ = "webtoon_rating_stats"
 
-    webtoon_id = Column(Integer, primary_key=True)
+    webtoon_id = Column(String, primary_key=True)
     average_rating = Column(Float, nullable=False, default=0.0, server_default="0")
     review_count = Column(Integer, nullable=False, default=0, server_default="0")
     updated_at = Column(

--- a/webtoon/routers/auth.py
+++ b/webtoon/routers/auth.py
@@ -1,0 +1,28 @@
+"""Endpoints related to anonymous authentication helpers."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request, Response, status
+
+from webtoon.dependencies.auth import COOKIE_NAME, get_anonymous_user_id
+from webtoon.schemas.auth import AnonymousStatusResponse
+
+router = APIRouter(tags=["auth"])
+
+
+@router.get(
+    "/auth/anonymous",
+    response_model=AnonymousStatusResponse,
+    status_code=status.HTTP_200_OK,
+)
+def issue_anonymous_id(request: Request, response: Response) -> AnonymousStatusResponse:
+    """Return an existing anon_id cookie or create a new one."""
+
+    anon_id = request.cookies.get(COOKIE_NAME)
+    status = "existing"
+
+    if anon_id is None:
+        anon_id = get_anonymous_user_id(request, response)
+        status = "new"
+
+    return AnonymousStatusResponse(anon_id=anon_id, status=status)

--- a/webtoon/routers/reviews.py
+++ b/webtoon/routers/reviews.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, Path, Query, status
 from sqlalchemy.orm import Session
 
 from webtoon.db import get_session
 from webtoon.dependencies.auth import get_anonymous_user_id
-from webtoon.schemas.review import ReviewCreate, ReviewResponse
+from webtoon.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
 from webtoon.services.review_service import ReviewService
 
 router = APIRouter(tags=["reviews"])
@@ -16,7 +16,7 @@ router = APIRouter(tags=["reviews"])
 @router.post("/webtoons/review/", response_model=ReviewResponse, status_code=status.HTTP_201_CREATED)
 def create_review(
     payload: ReviewCreate,
-    webtoon_id: int = Query(..., ge=1, description="리뷰를 작성할 웹툰 ID"),
+    webtoon_id: str = Query(..., min_length=1, description="리뷰를 작성할 웹툰 ID"),
     db: Session = Depends(get_session),
     anonymous_user_id: str = Depends(get_anonymous_user_id),
 ) -> ReviewResponse:
@@ -29,3 +29,28 @@ def create_review(
         anonymous_user_id=anonymous_user_id,
     )
     return ReviewResponse.model_validate(review)
+
+
+@router.get(
+    "/webtoons/{webtoon_id}/reviews",
+    response_model=ReviewListResponse,
+    status_code=status.HTTP_200_OK,
+)
+def list_reviews(
+    webtoon_id: str = Path(..., min_length=1, description="리뷰를 조회할 웹툰 ID"),
+    page: int = Query(1, ge=1, description="조회할 페이지 번호"),
+    limit: int = Query(10, ge=1, description="한 페이지당 가져올 리뷰 개수"),
+    db: Session = Depends(get_session),
+) -> ReviewListResponse:
+    """Return paginated reviews for a specific webtoon."""
+
+    service = ReviewService(db)
+    stats, reviews = service.list_reviews(webtoon_id=webtoon_id, page=page, limit=limit)
+    return ReviewListResponse(
+        webtoon_id=stats.webtoon_id,
+        average_rating=stats.average_rating,
+        review_count=stats.review_count,
+        page=page,
+        limit=limit,
+        reviews=reviews,
+    )

--- a/webtoon/routers/reviews.py
+++ b/webtoon/routers/reviews.py
@@ -1,0 +1,31 @@
+"""Review-related API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from webtoon.db import get_session
+from webtoon.dependencies.auth import get_anonymous_user_id
+from webtoon.schemas.review import ReviewCreate, ReviewResponse
+from webtoon.services.review_service import ReviewService
+
+router = APIRouter(tags=["reviews"])
+
+
+@router.post("/webtoons/review/", response_model=ReviewResponse, status_code=status.HTTP_201_CREATED)
+def create_review(
+    payload: ReviewCreate,
+    webtoon_id: int = Query(..., ge=1, description="리뷰를 작성할 웹툰 ID"),
+    db: Session = Depends(get_session),
+    anonymous_user_id: str = Depends(get_anonymous_user_id),
+) -> ReviewResponse:
+    """Create a new review and update the corresponding rating stats."""
+
+    service = ReviewService(db)
+    review = service.create_review(
+        webtoon_id=webtoon_id,
+        payload=payload,
+        anonymous_user_id=anonymous_user_id,
+    )
+    return ReviewResponse.model_validate(review)

--- a/webtoon/routers/reviews.py
+++ b/webtoon/routers/reviews.py
@@ -9,6 +9,7 @@ from webtoon.db import get_session
 from webtoon.dependencies.auth import get_anonymous_user_id
 from webtoon.schemas.review import (
     ReviewCreate,
+    ReviewLikeResponse,
     ReviewListResponse,
     ReviewResponse,
     ReviewUpdate,
@@ -81,3 +82,20 @@ def update_review(
         anonymous_user_id=anonymous_user_id,
     )
     return ReviewResponse.model_validate(review)
+
+
+@router.post(
+    "/reviews/{review_id}/like",
+    response_model=ReviewLikeResponse,
+    status_code=status.HTTP_200_OK,
+)
+def like_review(
+    review_id: int = Path(..., ge=1, description="좋아요를 누를 리뷰 ID"),
+    db: Session = Depends(get_session),
+    anonymous_user_id: str = Depends(get_anonymous_user_id),
+) -> ReviewLikeResponse:
+    """Register a like for the given review on behalf of the anon user."""
+
+    service = ReviewService(db)
+    review = service.like_review(review_id=review_id, anonymous_user_id=anonymous_user_id)
+    return ReviewLikeResponse(review_id=review.id, likes=review.likes)

--- a/webtoon/routers/reviews.py
+++ b/webtoon/routers/reviews.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session
 
 from webtoon.db import get_session
 from webtoon.dependencies.auth import get_anonymous_user_id
-from webtoon.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse
+from webtoon.schemas.review import (
+    ReviewCreate,
+    ReviewListResponse,
+    ReviewResponse,
+    ReviewUpdate,
+)
 from webtoon.services.review_service import ReviewService
 
 router = APIRouter(tags=["reviews"])
@@ -54,3 +59,25 @@ def list_reviews(
         limit=limit,
         reviews=reviews,
     )
+
+
+@router.put(
+    "/webtoons/{webtoon_id}/reviews",
+    response_model=ReviewResponse,
+    status_code=status.HTTP_200_OK,
+)
+def update_review(
+    payload: ReviewUpdate,
+    webtoon_id: str = Path(..., min_length=1, description="수정할 리뷰의 웹툰 ID"),
+    db: Session = Depends(get_session),
+    anonymous_user_id: str = Depends(get_anonymous_user_id),
+) -> ReviewResponse:
+    """Update the review authored by the anon user for the given webtoon."""
+
+    service = ReviewService(db)
+    review = service.update_review(
+        webtoon_id=webtoon_id,
+        payload=payload,
+        anonymous_user_id=anonymous_user_id,
+    )
+    return ReviewResponse.model_validate(review)

--- a/webtoon/routers/search.py
+++ b/webtoon/routers/search.py
@@ -66,14 +66,15 @@ def search_webtoons(
             tags
         FROM normalized_webtoon
         WHERE (
-            title    LIKE ?
+            id        LIKE ?
+            OR title    LIKE ?
             OR authors  LIKE ?
             OR synopsis LIKE ?
             OR tags     LIKE ?
         )
     """
 
-    params: list[str] = [pattern, pattern, pattern, pattern]
+    params: list[str] = [pattern, pattern, pattern, pattern, pattern]
 
     # day가 넘어왔으면 요일 필터 추가
     if day is not None:

--- a/webtoon/routers/webtoons.py
+++ b/webtoon/routers/webtoons.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 from webtoon.database import get_db
 
@@ -63,6 +63,35 @@ def get_webtoons_by_day(day: str):
         media_type="application/json; charset=utf-8"
     )
 
+
+@router.get("/webtoons/sample")
+def get_sample_webtoons(
+    limit: int = Query(5, ge=1, le=50, description="가져올 테스트용 웹툰 개수 (기본 5)")
+):
+    """
+    테스트용으로 소량의 웹툰만 조회하는 엔드포인트.
+    """
+    rows = cursor.execute(
+        """
+        SELECT
+            id,
+            thumbnail,
+            title,
+            updateDays,
+            authors,
+            tags
+        FROM normalized_webtoon
+        ORDER BY id
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    data = [dict(r) for r in rows]
+    return JSONResponse(
+        content={"count": len(data), "webtoons": data},
+        media_type="application/json; charset=utf-8",
+    )
+
 @router.get("/webtoons_title/day/{day}")
 def get_webtoons_by_day(day: str):
     valid_days = ["MON", "TUE", "WED", "THR", "FRI", "SAT", "SUN"]
@@ -80,4 +109,3 @@ def get_webtoons_by_day(day: str):
         content={"count": len(data), "webtoons": data},
         media_type="application/json; charset=utf-8"
     )
-

--- a/webtoon/schemas/__init__.py
+++ b/webtoon/schemas/__init__.py
@@ -1,5 +1,6 @@
 """Pydantic schemas exposed by the webtoon package."""
 
+from webtoon.schemas.auth import AnonymousStatusResponse
 from webtoon.schemas.review import ReviewCreate, ReviewResponse
 
-__all__ = ["ReviewCreate", "ReviewResponse"]
+__all__ = ["AnonymousStatusResponse", "ReviewCreate", "ReviewResponse"]

--- a/webtoon/schemas/__init__.py
+++ b/webtoon/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Pydantic schemas exposed by the webtoon package."""
+
+from webtoon.schemas.review import ReviewCreate, ReviewResponse
+
+__all__ = ["ReviewCreate", "ReviewResponse"]

--- a/webtoon/schemas/auth.py
+++ b/webtoon/schemas/auth.py
@@ -1,0 +1,14 @@
+"""Schemas for authentication-related endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class AnonymousStatusResponse(BaseModel):
+    """Represents the anon_id status returned by /auth/anonymous."""
+
+    anon_id: str
+    status: Literal["new", "existing"]

--- a/webtoon/schemas/review.py
+++ b/webtoon/schemas/review.py
@@ -1,0 +1,30 @@
+"""Request/response schemas for review endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ReviewCreate(BaseModel):
+    """Payload used when clients submit a new review."""
+
+    content: str = Field(..., min_length=1, max_length=2000)
+    rating: float = Field(..., ge=0, le=5)
+
+
+class ReviewResponse(BaseModel):
+    """Response schema mirroring the review record returned by the API."""
+
+    id: int
+    webtoon_id: int
+    content: str
+    rating: float
+    likes: int
+    created_at: datetime
+    anonymous_user_id: str
+
+    model_config = {
+        "from_attributes": True,
+    }

--- a/webtoon/schemas/review.py
+++ b/webtoon/schemas/review.py
@@ -62,3 +62,10 @@ class ReviewListResponse(BaseModel):
     page: int
     limit: int
     reviews: List[ReviewListItem]
+
+
+class ReviewLikeResponse(BaseModel):
+    """Response for the review like endpoint."""
+
+    review_id: int
+    likes: int

--- a/webtoon/schemas/review.py
+++ b/webtoon/schemas/review.py
@@ -15,6 +15,13 @@ class ReviewCreate(BaseModel):
     rating: float = Field(..., ge=0, le=5)
 
 
+class ReviewUpdate(BaseModel):
+    """Payload used when clients modify an existing review."""
+
+    content: str = Field(..., min_length=1, max_length=2000)
+    rating: float = Field(..., ge=0, le=5)
+
+
 class ReviewResponse(BaseModel):
     """Response schema mirroring the review record returned by the API."""
 
@@ -25,6 +32,7 @@ class ReviewResponse(BaseModel):
     likes: int
     created_at: datetime
     anonymous_user_id: str
+    updated_at: datetime
 
     model_config = {
         "from_attributes": True,

--- a/webtoon/schemas/review.py
+++ b/webtoon/schemas/review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import List
 
 from pydantic import BaseModel, Field
 
@@ -18,7 +19,7 @@ class ReviewResponse(BaseModel):
     """Response schema mirroring the review record returned by the API."""
 
     id: int
-    webtoon_id: int
+    webtoon_id: str
     content: str
     rating: float
     likes: int
@@ -28,3 +29,28 @@ class ReviewResponse(BaseModel):
     model_config = {
         "from_attributes": True,
     }
+
+
+class ReviewListItem(BaseModel):
+    """Lightweight representation used when listing reviews."""
+
+    id: int
+    content: str
+    rating: float
+    likes: int
+    created_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class ReviewListResponse(BaseModel):
+    """Envelope returned by the review list endpoint."""
+
+    webtoon_id: str
+    average_rating: float
+    review_count: int
+    page: int
+    limit: int
+    reviews: List[ReviewListItem]

--- a/webtoon/services/__init__.py
+++ b/webtoon/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer objects for the webtoon backend."""
+
+from webtoon.services.review_service import ReviewService
+
+__all__ = ["ReviewService"]

--- a/webtoon/services/review_service.py
+++ b/webtoon/services/review_service.py
@@ -1,0 +1,78 @@
+"""Encapsulates review business logic and DB interactions."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from fastapi import HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from webtoon.models import Review, WebtoonRatingStats
+from webtoon.schemas.review import ReviewCreate
+
+
+class ReviewService:
+    """Coordinates review persistence and rating aggregation."""
+
+    _WEBTOON_EXISTS_QUERY: Final[str] = (
+        "SELECT 1 FROM normalized_webtoon WHERE id = :webtoon_id LIMIT 1"
+    )
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create_review(
+        self,
+        *,
+        webtoon_id: int,
+        payload: ReviewCreate,
+        anonymous_user_id: str,
+    ) -> Review:
+        self._ensure_webtoon_exists(webtoon_id)
+
+        review = Review(
+            webtoon_id=webtoon_id,
+            content=payload.content,
+            rating=payload.rating,
+            anonymous_user_id=anonymous_user_id,
+        )
+        self._db.add(review)
+        self._db.flush()
+
+        self._update_rating_stats(webtoon_id, payload.rating)
+
+        try:
+            self._db.commit()
+        except Exception:
+            self._db.rollback()
+            raise
+
+        self._db.refresh(review)
+        return review
+
+    def _ensure_webtoon_exists(self, webtoon_id: int) -> None:
+        exists = self._db.execute(
+            text(self._WEBTOON_EXISTS_QUERY), {"webtoon_id": webtoon_id}
+        ).scalar()
+        if not exists:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="해당 웹툰을 찾을 수 없습니다.",
+            )
+
+    def _update_rating_stats(self, webtoon_id: int, new_rating: float) -> None:
+        stats = self._db.get(WebtoonRatingStats, webtoon_id)
+
+        if stats is None:
+            stats = WebtoonRatingStats(
+                webtoon_id=webtoon_id,
+                average_rating=new_rating,
+                review_count=1,
+            )
+            self._db.add(stats)
+            return
+
+        total = stats.average_rating * stats.review_count + new_rating
+        stats.review_count += 1
+        stats.average_rating = total / stats.review_count


### PR DESCRIPTION
GET /auth/anonymous 엔드포인트를 추가해 anon 쿠키를 재사용하거나 새로 발급해 주도록 했고, FastAPI 라우터에 등록했습니다

응답 스키마 AnonymousStatusResponse를 정의해 anon_id와 status(new/existing)를 표준화했습니다 

README에 Anonymous ID API 섹션을 추가해 요청/응답 예시, 실패 케이스, 쿠키 정책을 문서화했습니다